### PR TITLE
Fix typo of extension name in composer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"typo3/cms-core": "*"
 	},
 	"replace": {
-		"url-forwarding": "self.version",
+		"url_forwarding": "self.version",
 		"typo3-ter/url-forwarding": "self.version"
 	},
 	"autoload": {


### PR DESCRIPTION
The name will be used to create the folder so it needs to be spelled with '_' instead of '-'.